### PR TITLE
[#149002995] stop eating edoc path config

### DIFF
--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -84,8 +84,9 @@ format_error(Reason) ->
 has_configured_paths(EdocOpts) ->
     proplists:get_value(dir, EdocOpts) =/= undefined.
 
-add_to_paths(Opts, Path) ->
-    case proplists:get_value(doc_path, Opts) of
-        undefined -> [{doc_path, [Path]} | Opts];
-        Paths -> lists:keyreplace(doc_path, 1, Opts, {doc_path, [Path | Paths]})
-    end.
+add_to_paths([], Path) ->
+    [{doc_path, [Path]}];
+add_to_paths([{doc_path, Paths}|T], Path) ->
+    [{doc_path, [Path | Paths]} | T];
+add_to_paths([H|T], Path) ->
+    [H | add_to_paths(T, Path)].

--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -84,9 +84,8 @@ format_error(Reason) ->
 has_configured_paths(EdocOpts) ->
     proplists:get_value(dir, EdocOpts) =/= undefined.
 
-add_to_paths([], Path) ->
-    [{doc_path, [Path]}];
-add_to_paths([{doc_path, Paths}|T], Path) ->
-    [{doc_path, [Path | Paths]} | T];
-add_to_paths([H|T], Path) ->
-    [H | add_to_paths(Path, T)].
+add_to_paths(Opts, Path) ->
+    case proplists:get_value(doc_path, Opts) of
+        undefined -> [{doc_path, [Path]} | Opts];
+        Paths -> lists:keyreplace(doc_path, 1, Opts, {doc_path, [Path | Paths]})
+    end.


### PR DESCRIPTION
## Pivotal Cards:
- [Error in rebar3 when parsing 'complicated' edoc configuration options](https://www.pivotaltracker.com/story/show/149002995)
 
## Things Done:
-  stop eating the `H` of a list when parsing out doc paths

## Example:
- without this fix, rebar3 generates the following output when creating edocs (when run with DEBUG=1):
```
===> Running edoc for twilio_ivr
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for worker_core
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for message_routing
edoc: warning: could not read 'ome/vagrant/projects/vhx/apps/worker_core/doc/edoc-info': no such file or directory.
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for web_core
edoc: warning: could not read 'e/vagrant/projects/vhx/apps/message_routing/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'ome/vagrant/projects/vhx/apps/worker_core/doc/edoc-info': no such file or directory.
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for rest_config
edoc: warning: could not read 'grant/projects/vhx/apps/web_core/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'e/vagrant/projects/vhx/apps/message_routing/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'ome/vagrant/projects/vhx/apps/worker_core/doc/edoc-info': no such file or directory.
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for elasticstore_transform
edoc: warning: could not read 'ojects/vhx/apps/rest_config/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'grant/projects/vhx/apps/web_core/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'e/vagrant/projects/vhx/apps/message_routing/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'ome/vagrant/projects/vhx/apps/worker_core/doc/edoc-info': no such file or directory.
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for database_core
edoc: warning: could not read 'elasticstore_transform/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'ojects/vhx/apps/rest_config/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'grant/projects/vhx/apps/web_core/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'e/vagrant/projects/vhx/apps/message_routing/doc/edoc-info': no such file or directory.
edoc: warning: could not read 'ome/vagrant/projects/vhx/apps/worker_core/doc/edoc-info': no such file or directory.
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for transform_factory
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace or consult rebar3.crashdump
===> Uncaught error: {case_clause,
                             {{'EXIT',
                               {badarg,
                                [{io_lib,format,
                                  ["cannot handle URI: '~ts'.",
                                   [[116,120,118,47,47,97,109,112,112,112,97,
                                     115,114,47,
                                     {doc_path,
                                      ["elasticstore_transform/doc",
                                       "ojects/vhx/apps/rest_config/doc",
                                       "grant/projects/vhx/apps/web_core/doc",
                                       "e/vagrant/projects/vhx/apps/message_routing/doc",
                                       "ome/vagrant/projects/vhx/apps/worker_core/doc",
                                       "home/vagrant/projects/vhx/apps/twilio_ivr/doc"]},
                                     47,101,100,111,99,45,105,110,102,111]]],
                                  [{file,"io_lib.erl"},{line,168}]},
                                 {edoc_lib,uri_get,1,
                                  [{file,"edoc_lib.erl"},{line,485}]},
                                 {edoc_lib,uri_get_info_file,1,
                                  [{file,"edoc_lib.erl"},{line,756}]},
                                 {edoc_lib,'-get_doc_links/3-lc$^0/1-0-',1,
                                  [{file,"edoc_lib.erl"},{line,895}]},
                                 {edoc_lib,get_doc_links,3,
                                  [{file,"edoc_lib.erl"},{line,895}]},
                                 {edoc_lib,get_doc_env,3,
                                  [{file,"edoc_lib.erl"},{line,959}]},
                                 {edoc,run,2,[{file,"edoc.erl"},{line,328}]},
                                 {rebar_prv_edoc,'-do/1-fun-0-',6,
                                  [{file,
                                    "/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_prv_edoc.erl"},
                                   {line,48}]}]}},
                              true}}
===> Stack trace to the error location:
[{rebar_prv_edoc,'-do/1-fun-0-',6,
                 [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_prv_edoc.erl"},
                  {line,50}]},
 {lists,foldl,3,[{file,"lists.erl"},{line,1262}]},
 {rebar_prv_edoc,do,1,
                 [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_prv_edoc.erl"},
                  {line,43}]},
 {rebar_core,do,2,
             [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
              {line,153}]},
 {rebar3,main,1,
         [{file,"/home/tristan/Devel/rebar3/_build/default/lib/rebar/src/rebar3.erl"},
          {line,66}]},
 {escript,run,2,[{file,"escript.erl"},{line,757}]},
 {escript,start,1,[{file,"escript.erl"},{line,277}]},
 {init,start_it,1,[]}]
```
After the fix:

```
===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for twilio_ivr
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for worker_core
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for message_routing
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for web_core
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for rest_config
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for elasticstore_transform
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for database_core
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for transform_factory
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for physical_queue
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for sample_worker
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for twilio_adapter
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for vhx_utilities
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for launch_contact_timer
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for ewt_worker
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for interaction_web
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for bootstrap
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for timezones
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for ct_helper
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for ldap_proxy
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for sample_web
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for virtual_queue
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for callback_expression
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for elasticsearch_index_creator
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for outbound_contact_worker
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for gui_server
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for asap_callback
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for web_customer_interaction
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for http_proxy
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined

===> run_hooks("/home/vagrant/projects/vhx", pre_hooks, edoc) -> no hooks defined

===> Running edoc for scheduled_callback
===> run_hooks("/home/vagrant/projects/vhx", post_hooks, edoc) -> no hooks defined
```

## How To Test
- checkout `non_alphanumeric_group_bug_#148620087` branch in vhx
- change `docs` profile to look like this:
```
{docs, [
                {edoc_opts, [{private, true}]}
            ]},
```
- run edoc using the built in rebar3, see the error and grimace
- build this version of rebar3 by running `./bootstrap` at this application's root
- use the newly created version of rebar3 to run edocs and see application documentation generated and thrown in a `doc` folder at the root of each application (`apps/<app name>/doc`)